### PR TITLE
Improve documentation of filters

### DIFF
--- a/src/main/php/LoggerLoggingEvent.php
+++ b/src/main/php/LoggerLoggingEvent.php
@@ -141,10 +141,10 @@ class LoggerLoggingEvent {
 	 * Returns the full qualified classname.
 	 * TODO: PHP does contain namespaces in 5.3. Those should be returned too, 
 	 */
-	public function getFullQualifiedClassname() {
-		return $this->fqcn;
-	}
-
+	 public function getFullQualifiedClassname() {
+		 return $this->fqcn;
+	 }
+	 
 	/**
 	 * Set the location information for this logging event. The collected
 	 * information is cached for future use.
@@ -191,14 +191,6 @@ class LoggerLoggingEvent {
 			$this->locationInfo = new LoggerLocationInfo($locationInfo, $this->fqcn);
 		}
 		return $this->locationInfo;
-	}
-
-	/**
-	 * Sets the event's location info. Can be used to override the default info.
-	 * @param LoggerLocationInfo $locationInfo
-	 */
-	public function setLocationInformation(LoggerLocationInfo $locationInfo) {
-		$this->locationInfo = $locationInfo;
 	}
 
 	/**

--- a/src/main/php/LoggerLoggingEvent.php
+++ b/src/main/php/LoggerLoggingEvent.php
@@ -141,10 +141,10 @@ class LoggerLoggingEvent {
 	 * Returns the full qualified classname.
 	 * TODO: PHP does contain namespaces in 5.3. Those should be returned too, 
 	 */
-	 public function getFullQualifiedClassname() {
-		 return $this->fqcn;
-	 }
-	 
+	public function getFullQualifiedClassname() {
+		return $this->fqcn;
+	}
+
 	/**
 	 * Set the location information for this logging event. The collected
 	 * information is cached for future use.
@@ -191,6 +191,14 @@ class LoggerLoggingEvent {
 			$this->locationInfo = new LoggerLocationInfo($locationInfo, $this->fqcn);
 		}
 		return $this->locationInfo;
+	}
+
+	/**
+	 * Sets the event's location info. Can be used to override the default info.
+	 * @param LoggerLocationInfo $locationInfo
+	 */
+	public function setLocationInformation(LoggerLocationInfo $locationInfo) {
+		$this->locationInfo = $locationInfo;
 	}
 
 	/**

--- a/src/site/xdoc/docs/filters.xml
+++ b/src/site/xdoc/docs/filters.xml
@@ -217,7 +217,9 @@ array(
 			</subsection>
 			
 			<subsection name="LoggerFilterLevelRange" id="LoggerFilterLevelRange">
-				<p>This filter accepts or denies logging events if their log level is within the specified range.</p>
+                <p>This filter denies logging events if their log level is outside the specified range. None of the
+                parameters are required but it makes sense to set at least one of <code>levelMin</code> and
+                <code>levelMax</code>.</p>
 				
 				<h4>Configurable parameters</h4>
 				
@@ -235,14 +237,14 @@ array(
 						<tr>
 							<td>levelMin</td>
 							<td>LoggerLevel</td>
-							<td><strong>Yes</strong></td>
+							<td>No</td>
 							<td>-</td>
 							<td>The minimum level to log. If set, levels lower than this will be denied.</td>
 						</tr>
 						<tr>
 							<td>levelMax</td>
 							<td>LoggerLevel</td>
-							<td><strong>Yes</strong></td>
+							<td>No</td>
 							<td>-</td>
 							<td>The maximum level to log. If set, levels higher than this will be denied.</td>
 						</tr>
@@ -251,7 +253,8 @@ array(
 							<td>boolean</td>
 							<td>No</td>
 							<td>true</td>
-							<td>If true, the matching log level is accepted, denied otherwise.</td>
+                            <td>If true, a log event within the specified range is accepted. Otherwise, the filter
+                            remains neutral.</td>
 						</tr>
 					</tbody>
 				</table>
@@ -270,7 +273,8 @@ array(
 			</subsection>
 			
 			<subsection name="LoggerFilterStringMatch" id="LoggerFilterStringMatch">
-				<p>This filter allows or denies logging events if their message contains a given string.</p>
+                <p>This filter allows or denies logging events if their message contains a given string. If no match
+                is found the filter remains neutral.</p>
 				
 				<h4>Configurable parameters</h4>
 				
@@ -290,21 +294,15 @@ array(
 							<td>LoggerLevel</td>
 							<td><strong>Yes</strong></td>
 							<td>-</td>
-							<td>The level to match</td>
-						</tr>
-						<tr>
-							<td>levelMax</td>
-							<td>LoggerLevel</td>
-							<td><strong>Yes</strong></td>
-							<td>-</td>
-							<td>The level to match</td>
+							<td>The string to match. Matches are case sensitive.</td>
 						</tr>
 						<tr>
 							<td>acceptOnMatch</td>
 							<td>boolean</td>
 							<td>No</td>
 							<td>true</td>
-							<td>If true, the matching log level is accepted, denied otherwise.</td>
+                            <td>If true and a match is found, the matching log event is accepted. If false and a
+                            match is found, the matching log event is denied.</td>
 						</tr>
 					</tbody>
 				</table>

--- a/src/site/xdoc/docs/filters.xml
+++ b/src/site/xdoc/docs/filters.xml
@@ -217,9 +217,9 @@ array(
 			</subsection>
 			
 			<subsection name="LoggerFilterLevelRange" id="LoggerFilterLevelRange">
-                <p>This filter denies logging events if their log level is outside the specified range. None of the
-                parameters are required but it makes sense to set at least one of <code>levelMin</code> and
-                <code>levelMax</code>.</p>
+				<p>This filter denies logging events if their log level is outside the specified range. None of the
+				parameters are required but it makes sense to set at least one of <code>levelMin</code> and
+				<code>levelMax</code>.</p>
 				
 				<h4>Configurable parameters</h4>
 				
@@ -253,8 +253,8 @@ array(
 							<td>boolean</td>
 							<td>No</td>
 							<td>true</td>
-                            <td>If true, a log event within the specified range is accepted. Otherwise, the filter
-                            remains neutral.</td>
+							<td>If true, a log event within the specified range is accepted. Otherwise, the filter
+							remains neutral.</td>
 						</tr>
 					</tbody>
 				</table>
@@ -273,8 +273,8 @@ array(
 			</subsection>
 			
 			<subsection name="LoggerFilterStringMatch" id="LoggerFilterStringMatch">
-                <p>This filter allows or denies logging events if their message contains a given string. If no match
-                is found the filter remains neutral.</p>
+				<p>This filter allows or denies logging events if their message contains a given string. If no match
+				is found the filter remains neutral.</p>
 				
 				<h4>Configurable parameters</h4>
 				
@@ -301,8 +301,8 @@ array(
 							<td>boolean</td>
 							<td>No</td>
 							<td>true</td>
-                            <td>If true and a match is found, the matching log event is accepted. If false and a
-                            match is found, the matching log event is denied.</td>
+							<td>If true and a match is found, the matching log event is accepted. If false and a
+							match is found, the matching log event is denied.</td>
 						</tr>
 					</tbody>
 				</table>


### PR DESCRIPTION
This patch fixes some incorrect statements on the Log4PHP filters documentation. The most important removes a non-existent attribute on the `LoggerFilterPullRequest` element, most likely a result of copy and pasting from the previous filter documentation. I've also updated some of the requirements based on what the code says is actually required, and tried to clarify the accept/deny/neutral decisions of each filter.
