### PR TITLE
tweak log4php file:line column to optionally ignore log4php wrappers and optionally shorten file path

### DIFF
--- a/src/main/php/LoggerLoggingEvent.php
+++ b/src/main/php/LoggerLoggingEvent.php
@@ -191,16 +191,16 @@ class LoggerLoggingEvent {
 					if (isset($hop['file']) and isset(self::$ignoreFileRegex)) {
 						if(1 === preg_match(self::$ignoreFileRegex, $hop['file'])) {
 							// come here if detected a caller wrapper for log4php
-							$locationInfo['line'] =                                                              $prevHop['line'] ;
-							$locationInfo['file'] = preg_replace(self::$ignorePathRegexSrc, $ignorePathRegexDst, $prevHop['file']); // replace annoyingly verbose path prefix
+							$locationInfo['line'] =                                                                    $prevHop['line'] ;
+							$locationInfo['file'] = preg_replace(self::$ignorePathRegexSrc, self::$ignorePathRegexDst, $prevHop['file']); // replace annoyingly verbose path prefix
 							break;
 						}
 					}
 					// we are sometimes in functions = no class available: avoid php warning here
 					$className = strtolower($hop['class']);
 					if(!empty($className) and ($className == 'logger' or strtolower(get_parent_class($className)) == 'logger')) {
-						$locationInfo['line'] =                                                              $hop['line'] ;
-						$locationInfo['file'] = preg_replace(self::$ignorePathRegexSrc, $ignorePathRegexDst, $hop['file']); // replace annoyingly verbose path prefix
+						$locationInfo['line'] =                                                                    $hop['line'] ;
+						$locationInfo['file'] = preg_replace(self::$ignorePathRegexSrc, self::$ignorePathRegexDst, $hop['file']); // replace annoyingly verbose path prefix
 						break;
 					}
 				}


### PR DESCRIPTION
Inspired by [1]. Useful if log4php is itself wrapped by a caller class which you do not want showing up in syslog as the file:line. Plus, if file is unnecessarily long then this patch allows the path to be shortened.

[1] http://stackoverflow.com/questions/15219327/php-log4php-dynamically-set-fileline-column
