### PR TITLE
Replaced the deprecated function split() that will be removed in PHP 7.

### DIFF
--- a/src/examples/php/appender_socket_server.php
+++ b/src/examples/php/appender_socket_server.php
@@ -54,7 +54,7 @@ class Net_Server_Handler_Log extends Net_Server_Handler {
                     throw new Exception("Please use 'log4php.appender.default.useXml = false' in appender_socket.properties file!");
                 }
                 preg_match('/^(O:\d+)/', $data, $parts);
-                $events = split($parts[1], $data);
+                $events = explode($parts[1], $data);
                 array_shift($events);
                 $size = count($events);
                 for($i=0; $i<$size; $i++) {


### PR DESCRIPTION
Replaced split() with explode() to ensure smooth transition to PHP 7. WordPress is soon updating to PHP 7, and this code is used within the FBIA WordPress plugin making the swap necessary. 

For more information, see http://php.net/manual/en/function.split.php
