### PR TITLE
Support logging of PHP 7 error class

### DIFF
--- a/src/main/php/LoggerLoggingEvent.php
+++ b/src/main/php/LoggerLoggingEvent.php
@@ -133,7 +133,7 @@ class LoggerLoggingEvent {
 			$this->timeStamp = microtime(true);
 		}
 		
-		if ($throwable !== null && $throwable instanceof Exception) {
+		if ($throwable !== null) {
 			$this->throwableInfo = new LoggerThrowableInformation($throwable);
 		}
 	}

--- a/src/main/php/LoggerThrowableInformation.php
+++ b/src/main/php/LoggerThrowableInformation.php
@@ -38,7 +38,7 @@ class LoggerThrowableInformation {
 	 * @param $throwable - a throwable as a exception
 	 * @param $logger - Logger reference
 	 */
-	public function __construct(Exception $throwable) {
+	public function __construct($throwable) {
 		$this->throwable = $throwable;
 	}
 	


### PR DESCRIPTION
We are unable to log PHP Class Error via log4php. There is implemented only logging for Exception class.