### PR TITLE
Allow MDC use callable param

### DIFF
--- a/src/main/php/pattern/LoggerPatternConverter.php
+++ b/src/main/php/pattern/LoggerPatternConverter.php
@@ -101,8 +101,10 @@ abstract class LoggerPatternConverter {
 			return;
 		}
 		
-		if ($string instanceof Closure) {
-			$string = ($string)();
+		if (version_compare(phpversion(), '5.3.0', '>=')) {
+			if ($string instanceof Closure) {
+				$string = $string();
+			}
 		}
 		
 		$len = strlen($string);

--- a/src/main/php/pattern/LoggerPatternConverter.php
+++ b/src/main/php/pattern/LoggerPatternConverter.php
@@ -101,6 +101,10 @@ abstract class LoggerPatternConverter {
 			return;
 		}
 		
+		if ($string instanceof Closure) {
+			$string = ($string)();
+		}
+		
 		$len = strlen($string);
 	
 		// Trim the string if needed

--- a/src/test/php/LoggerIdGenerator.php
+++ b/src/test/php/LoggerIdGenerator.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * That's a singletone class
+ */
+
+class LoggerIdGenerator
+{
+	private static $instance;
+	private $requestId;
+	private $sequence = 1;
+
+	protected function __construct() {/* you can't create me */
+	}
+
+	public function getId() {
+		if($this->requestId == null) {
+			$dateTime = new DateTime();
+			$this->requestId = $dateTime->getTimestamp() . rand(1000, 9999);
+		}
+		return $this->requestId;
+	}
+
+	public function getSeq() {
+		return $this->sequence++;
+	}
+
+	public static function me() {
+		return self::getInstance();
+	}
+
+	final public static function getInstance() {
+
+		if(!isset(self::$instance)) {
+			self::$instance = new self;
+		}
+
+		return self::$instance;
+	}
+
+	final private function __clone() {/* do not clone me */
+	}
+}

--- a/src/test/php/LoggerMDCTest.php
+++ b/src/test/php/LoggerMDCTest.php
@@ -57,12 +57,12 @@ class LoggerMDCTest extends PHPUnit_Framework_TestCase {
 	public function testClosure() {
 		if (version_compare(phpversion(), '5.3.0', '>=')) {
 			LoggerMDC::put("requestSequence",
-				function() {
+				function () {
 					return sprintf("%02d", LoggerIdGenerator::me()->getSeq());
 				}
 			);
 			// Test in a cycle
-			for($i=1; $i <= 10; $i++) {
+			for ($i = 1; $i <= 10; $i++) {
 				$event = LoggerTestHelper::getInfoEvent(sprintf('Iteration %02d', $i));
 				$actual = $this->formatEvent($event, $this->pattern6);
 				$expected = sprintf("Iteration %02d - sequence: %02d", $i, $i);
@@ -78,7 +78,6 @@ class LoggerMDCTest extends PHPUnit_Framework_TestCase {
 			$expected = sprintf("Debug %02d - sequence: %02d", $i, $i);
 
 			self::assertEquals($expected, $actual);
-
 		} else {
 			// Closures available Since 5.3.0
 			self::assertSame(1, 1);

--- a/src/test/php/LoggerMDCTest.php
+++ b/src/test/php/LoggerMDCTest.php
@@ -42,7 +42,10 @@ class LoggerMDCTest extends PHPUnit_Framework_TestCase {
 	
 	/** A pattern without a key. */
 	private $pattern5 = "%-5p %c: %X %m";
-	
+
+	/** Pattern for closure */
+	private $pattern6 = "%m - sequence: %X{requestSequence}";
+
 	protected function setUp() {
 		LoggerMDC::clear();
 	}
@@ -50,7 +53,38 @@ class LoggerMDCTest extends PHPUnit_Framework_TestCase {
 	protected function tearDown() {
 		LoggerMDC::clear();
 	}
-	
+
+	public function testClosure() {
+		if (version_compare(phpversion(), '5.3.0', '>=')) {
+			LoggerMDC::put("requestSequence",
+				function() {
+					return sprintf("%02d", LoggerIdGenerator::me()->getSeq());
+				}
+			);
+			// Test in a cycle
+			for($i=1; $i <= 10; $i++) {
+				$event = LoggerTestHelper::getInfoEvent(sprintf('Iteration %02d', $i));
+				$actual = $this->formatEvent($event, $this->pattern6);
+				$expected = sprintf("Iteration %02d - sequence: %02d", $i, $i);
+				self::assertEquals($expected, $actual);
+			}
+			// Increment outside of MDC
+			self::assertEquals($i, LoggerIdGenerator::me()->getSeq());
+			$i++;
+
+			// Recheck MDC has correct sequence
+			$event = LoggerTestHelper::getDebugEvent(sprintf('Debug %02d', $i));
+			$actual = $this->formatEvent($event, $this->pattern6);
+			$expected = sprintf("Debug %02d - sequence: %02d", $i, $i);
+
+			self::assertEquals($expected, $actual);
+
+		} else {
+			// Closures available Since 5.3.0
+			self::assertSame(1, 1);
+		}
+	}
+
 	public function testPatterns() {
 
 		// Create some data to test with


### PR DESCRIPTION
up to now it is impossible to use anonymouse function in LoggerMDC

This small fix allows to use function as second parameter

```php
LoggerMDC::put("someSpecialVar",
	function() {
		return RequestIdGenerator::me()->getSeq();
	}
);

```